### PR TITLE
fix : ticket #41967 Query not supported and Node14

### DIFF
--- a/generators/app/templates/database/partials/getInitQueriesInsert.ejs
+++ b/generators/app/templates/database/partials/getInitQueriesInsert.ejs
@@ -1,5 +1,5 @@
 <%types.forEach(type => {_%>
-    <%if (type.typeName !== "Query" && type.typeName !== "Mutation"){_%>
+    <%if (type.typeName !== 'Query' && type.typeName !== 'Mutation'){_%>
         <%-type.typeName.toLowerCase()%>Tab.forEach(item =>{
             let temp = `INSERT INTO "<%-type.sqlTypeName%>"(
             <% let fieldInsertList = []
@@ -33,11 +33,11 @@
                 <%if (index < itemInsertList.length - 1 ) {_%>,<%}%>
                 
             <%});_%>
-                
+                )`
+                queriesInsert.push(temp)
+                })
         <%}%>
-        )`
-        queriesInsert.push(temp)
-    	})
+
     <%})_%>
 
     // JOINTABLES

--- a/generators/app/templates/terraform/lambda.tf
+++ b/generators/app/templates/terraform/lambda.tf
@@ -1,6 +1,6 @@
 data "archive_file" "init" {
   type        = "zip"
-  source_dir  =  "${path.module}/.."
+  source_dir  = "${path.module}/.."
   excludes    = ["terraform"]
   output_path = "${path.module}/lambda.zip"
 }
@@ -8,22 +8,22 @@ data "archive_file" "init" {
 
 resource "aws_lambda_function" "lambda" {
   source_code_hash = data.archive_file.init.output_base64sha256
-  function_name = var.lambda_name
-  description = "Lamdba for  testing"
-  role = aws_iam_role.instance.arn
-  filename = data.archive_file.init.output_path
-  handler = "index.handler"
-  runtime = "nodejs12.x"
-  timeout = 60
+  function_name    = var.lambda_name
+  description      = "Lamdba for  testing"
+  role             = aws_iam_role.instance.arn
+  filename         = data.archive_file.init.output_path
+  handler          = "index.handler"
+  runtime          = "nodejs14.x"
+  timeout          = 60
   environment {
     variables = {
-      SECRETARN = aws_secretsmanager_secret.example.arn
+      SECRETARN   = aws_secretsmanager_secret.example.arn
       RESOURCEARN = module.rds_aurora_postgresql.cluster_arn
-      DATABASE = var.db_name
+      DATABASE    = var.db_name
     }
   }
   provisioner "local-exec" {
-    command = <<EOT
+    command     = <<EOT
                 export arn=${module.rds_aurora_postgresql.cluster_arn}
                 export secretArn=${aws_secretsmanager_secret.example.arn}
                 rm -f final.yaml ../temp.yaml  
@@ -34,12 +34,12 @@ resource "aws_lambda_function" "lambda" {
               EOT
     interpreter = ["bash", "-c"]
   }
-  
+
 
 }
 
 resource "aws_lambda_permission" "lambda_permission" {
-  depends_on = [aws_api_gateway_deployment.myDeployement]
+  depends_on    = [aws_api_gateway_deployment.myDeployement]
   statement_id  = "AllowMyDemoAPIInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda.function_name

--- a/generators/app/templates/testLambdas/template.yaml
+++ b/generators/app/templates/testLambdas/template.yaml
@@ -1,19 +1,19 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
   lamda local demo
-  
+
 Resources:
   LambdaDemoFunction:
-    Type: AWS::Serverless::Function 
+    Type: AWS::Serverless::Function
     Properties:
       CodeUri: # le format est projectPath/
       Handler: index.handler # le format est filename.functionName
-      Runtime: nodejs12.x 
-      Timeout: 120  # par defaut 3s
+      Runtime: nodejs14.x
+      Timeout: 120 # par defaut 3s
       Policies: AWSLambdaDynamoDBExecutionRole
-      Environment : #Variables d'environement necessaires aux lambdas
-        Variables :
+      Environment: #Variables d'environement necessaires aux lambdas
+        Variables:
           DATABASE: "<%= appName%>_db"
           RESOURCEARN: "${arn}"
           SECRETARN: "${secretArn}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-aws-server-gamechanger",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Simple generator of a serverless GraphQL API that can be deployed on AWS from a GraphQL schema",
   "main": "generators/index.js",
   "files": [

--- a/src/app/templates/database/partials/getInitQueriesInsert.ejs
+++ b/src/app/templates/database/partials/getInitQueriesInsert.ejs
@@ -1,5 +1,5 @@
 <%types.forEach(type => {_%>
-    <%if (type.typeName !== "Query" && type.typeName !== "Mutation"){_%>
+    <%if (type.typeName !== 'Query' && type.typeName !== 'Mutation'){_%>
         <%-type.typeName.toLowerCase()%>Tab.forEach(item =>{
             let temp = `INSERT INTO "<%-type.sqlTypeName%>"(
             <% let fieldInsertList = []
@@ -33,19 +33,17 @@
                 <%if (index < itemInsertList.length - 1 ) {_%>,<%}%>
                 
             <%});_%>
-                
+                )`
+                queriesInsert.push(temp)
+                })
         <%}%>
-        )`
-        queriesInsert.push(temp)
-    	})
     <%})_%>
 
     // JOINTABLES
     <%_types.forEach(type => {
         type.fields.forEach(field => {
             if(field.joinTable.state){%>
-                
-                
+
                     <%if((field.relationType === relations.manyToMany && field.activeSide) || (field.relationType === relations.manyToOne && field.joinTable.state)){%>
                         <%-field.joinTable.name.toLowerCase()%>Tab.forEach(item =>{
                             let temp = `INSERT INTO "<%-field.joinTable.name.toLowerCase()%>"(
@@ -54,9 +52,8 @@
                                 VALUES (` + item.<%-field.joinTable.contains[0].fieldName.toLowerCase()%>_id +` ,
                                 ` + item.<%-field.joinTable.contains[1].fieldName.toLowerCase()%>_id + `)`
                                 queriesInsert.push(temp)
-                                })                    
-                <%}
-                
+                        })
+                    <%}
                 
                 if(field.relationType === relations.selfJoinMany){%>
                     <%-field.joinTable.name.toLowerCase()%>Tab.forEach(item =>{
@@ -66,16 +63,8 @@
                             VALUES (` + item.<%-field.joinTable.contains[0].fieldName.toLowerCase()%>_id +` ,
                                 ` + item.<%-field.joinTable.contains[0].type.toLowerCase()%>_id + `)`
                                 queriesInsert.push(temp)
-                                })
-
-
+                    })
                 <%}
-                
-
-                    
-
-
-                
             }
             
         })

--- a/src/app/templates/terraform/lambda.tf
+++ b/src/app/templates/terraform/lambda.tf
@@ -1,6 +1,6 @@
 data "archive_file" "init" {
   type        = "zip"
-  source_dir  =  "${path.module}/.."
+  source_dir  = "${path.module}/.."
   excludes    = ["terraform"]
   output_path = "${path.module}/lambda.zip"
 }
@@ -8,22 +8,22 @@ data "archive_file" "init" {
 
 resource "aws_lambda_function" "lambda" {
   source_code_hash = data.archive_file.init.output_base64sha256
-  function_name = var.lambda_name
-  description = "Lamdba for  testing"
-  role = aws_iam_role.instance.arn
-  filename = data.archive_file.init.output_path
-  handler = "index.handler"
-  runtime = "nodejs12.x"
-  timeout = 60
+  function_name    = var.lambda_name
+  description      = "Lamdba for  testing"
+  role             = aws_iam_role.instance.arn
+  filename         = data.archive_file.init.output_path
+  handler          = "index.handler"
+  runtime          = "nodejs14.x"
+  timeout          = 60
   environment {
     variables = {
-      SECRETARN = aws_secretsmanager_secret.example.arn
+      SECRETARN   = aws_secretsmanager_secret.example.arn
       RESOURCEARN = module.rds_aurora_postgresql.cluster_arn
-      DATABASE = var.db_name
+      DATABASE    = var.db_name
     }
   }
   provisioner "local-exec" {
-    command = <<EOT
+    command     = <<EOT
                 export arn=${module.rds_aurora_postgresql.cluster_arn}
                 export secretArn=${aws_secretsmanager_secret.example.arn}
                 rm -f final.yaml ../temp.yaml  
@@ -34,12 +34,12 @@ resource "aws_lambda_function" "lambda" {
               EOT
     interpreter = ["bash", "-c"]
   }
-  
+
 
 }
 
 resource "aws_lambda_permission" "lambda_permission" {
-  depends_on = [aws_api_gateway_deployment.myDeployement]
+  depends_on    = [aws_api_gateway_deployment.myDeployement]
   statement_id  = "AllowMyDemoAPIInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda.function_name

--- a/src/app/templates/testLambdas/template.yaml
+++ b/src/app/templates/testLambdas/template.yaml
@@ -1,19 +1,19 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
   lamda local demo
-  
+
 Resources:
   LambdaDemoFunction:
-    Type: AWS::Serverless::Function 
+    Type: AWS::Serverless::Function
     Properties:
       CodeUri: # le format est projectPath/
       Handler: index.handler # le format est filename.functionName
-      Runtime: nodejs12.x 
-      Timeout: 120  # par defaut 3s
+      Runtime: nodejs14.x
+      Timeout: 120 # par defaut 3s
       Policies: AWSLambdaDynamoDBExecutionRole
-      Environment : #Variables d'environement necessaires aux lambdas
-        Variables :
+      Environment: #Variables d'environement necessaires aux lambdas
+        Variables:
           DATABASE: "<%= appName%>_db"
           RESOURCEARN: "${arn}"
           SECRETARN: "${secretArn}"


### PR DESCRIPTION
Fix de l'erreur du type Query qui provient du fichier ejs dont un bout
de code généré était hors du if block où il était censé être.
Transition pour les lambdas du runtime 12.xx vers 14.xx